### PR TITLE
librepology: Add filters

### DIFF
--- a/librepology/Cargo.toml
+++ b/librepology/Cargo.toml
@@ -15,3 +15,12 @@ failure = "0.1"
 log = "0.4"
 derive_more = "0.14"
 curl = "0.4"
+
+filters    = { version = "0.3", optional = true }
+derive-new = { version = "0.5", optional = true }
+
+[features]
+# By default, we include the filters functionality
+default = [ "packagefilters" ]
+
+packagefilters = ["filters", "derive-new"]

--- a/librepology/src/lib.rs
+++ b/librepology/src/lib.rs
@@ -5,8 +5,16 @@ extern crate url;
 extern crate url_serde;
 extern crate curl;
 
+#[cfg(feature = "packagefilters")]
+extern crate filters;
+#[cfg(feature = "packagefilters")]
+#[macro_use] extern crate derive_new;
+
 #[macro_use] extern crate serde_derive;
 #[macro_use] extern crate log;
 #[macro_use] extern crate derive_more;
 
 pub mod v1;
+
+#[cfg(feature = "packagefilters")]
+pub mod packagefilters;

--- a/librepology/src/packagefilters.rs
+++ b/librepology/src/packagefilters.rs
@@ -1,0 +1,81 @@
+use filters::filter::Filter;
+
+use crate::v1::types::{Package, Repo, Name, Status, Version, License, Maintainer};
+
+
+#[derive(new, Debug)]
+pub struct PackageRepoNameFilter(Repo);
+
+/// Filter implementation for PackageRepoNameFilter
+///
+/// filters based on _equality_!
+impl Filter<Package> for PackageRepoNameFilter {
+    fn filter(&self, package: &Package) -> bool {
+        self.0 == *package.repo()
+    }
+}
+
+
+#[derive(new, Debug)]
+pub struct PackageNameFilter(Name);
+
+/// Filter implementation for PackageNameFilter
+///
+/// filters based on _equality_!
+impl Filter<Package> for PackageNameFilter {
+    fn filter(&self, package: &Package) -> bool {
+        self.0 == *package.name()
+    }
+}
+
+
+#[derive(new, Debug)]
+pub struct PackageVersionFilter(Version);
+
+/// Filter implementation for PackageVersionFilter
+///
+/// filters based on _equality_!
+impl Filter<Package> for PackageVersionFilter {
+    fn filter(&self, package: &Package) -> bool {
+        self.0 == *package.version()
+    }
+}
+
+
+#[derive(new, Debug)]
+pub struct PackageStatusFilter(Status);
+
+/// Filter implementation for PackageStatusFilter
+///
+/// filters based on _equality_!
+impl Filter<Package> for PackageStatusFilter {
+    fn filter(&self, package: &Package) -> bool {
+        package.status().map(|s| self.0 == *s).unwrap_or(false)
+    }
+}
+
+
+#[derive(new, Debug)]
+pub struct PackageLicenseFilter(License);
+
+/// Filter implementation for PackageLicenseFilter
+///
+/// filters based on _equality_!
+impl Filter<Package> for PackageLicenseFilter {
+    fn filter(&self, package: &Package) -> bool {
+        package.licenses().map(|lcs| lcs.iter().any(|l| self.0 == *l)).unwrap_or(false)
+    }
+}
+
+
+#[derive(new, Debug)]
+pub struct PackageMaintainerFilter(Maintainer);
+
+/// Filter implementation for PackageMaintainerFilter
+///
+/// filters based on _equality_!
+impl Filter<Package> for PackageMaintainerFilter {
+    fn filter(&self, package: &Package) -> bool {
+        package.maintainers().map(|mts| mts.iter().any(|m| self.0 == *m)).unwrap_or(false)
+    }
+}

--- a/librepology/src/v1/types.rs
+++ b/librepology/src/v1/types.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use url::Url;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize)]
 pub struct Package {
     /// name of repository for this package
     repo: Repo,
@@ -71,7 +71,7 @@ impl Package {
 
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize)]
 pub struct Problem {
     #[serde(rename = "repo")]
     repo: Repo,
@@ -112,7 +112,7 @@ impl Problem {
 }
 
 // name of repository for this package
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize)]
 pub struct Repo(String);
 
 impl Deref for Repo {
@@ -124,7 +124,7 @@ impl Deref for Repo {
 }
 
 // package name as in repository (if different from version)
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize)]
 pub struct Name(String);
 
 impl Deref for Name {
@@ -136,7 +136,7 @@ impl Deref for Name {
 }
 
 // package version (sanitized)
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize)]
 pub struct Version(String);
 
 impl Deref for Version {
@@ -148,7 +148,7 @@ impl Deref for Version {
 }
 
 // package status
-#[derive(Clone, Debug, Serialize, Deserialize, Display)]
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Display)]
 pub enum Status {
     #[serde(rename = "newest")]
     #[display(fmt = "newest")]
@@ -192,7 +192,7 @@ pub enum Status {
 }
 
 // one-line description of the package
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize)]
 pub struct Summary(String);
 
 impl Deref for Summary {
@@ -204,7 +204,7 @@ impl Deref for Summary {
 }
 
 // list of package categories
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize)]
 pub struct Category(String);
 
 impl Deref for Category {
@@ -216,7 +216,7 @@ impl Deref for Category {
 }
 
 // list of package licenses
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize)]
 pub struct License(String);
 
 impl Deref for License {
@@ -228,7 +228,7 @@ impl Deref for License {
 }
 
 // list of package maintainers
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize)]
 pub struct Maintainer(String);
 
 impl Deref for Maintainer {
@@ -264,7 +264,7 @@ impl Deref for Download {
 }
 
 // list of package downloads
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize)]
 pub struct EffName(String);
 
 impl Deref for EffName {

--- a/librepology/src/v1/types.rs
+++ b/librepology/src/v1/types.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use url::Url;
 
-#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Package {
     /// name of repository for this package
     repo: Repo,


### PR DESCRIPTION
This adds filters in librepology.

They can be used to implement a filtering frontend. Not sure whether we want this or whether it would be more intelligent to 

```
repolocli --output json something something | jq 'filter(...)' | repolocli --stdin something something
```

Because this way we get more flexibility.